### PR TITLE
Fix results container visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
             </div>
         </div>
         
-        <div class="results" id="results-container" style="display: none;">
+        <div class="results hidden" id="results-container">
             <div class="result-card">
                 <div class="result-header">Your Estimated APE Rewards</div>
                 
@@ -235,7 +235,7 @@
                 <div class="pool-breakdown">
                     <h3 class="breakdown-title">Rewards Breakdown by Pool</h3>
                     <div class="breakdown-grid">
-                        <div class="breakdown-item" id="ape-breakdown" style="display: none;">
+                        <div class="breakdown-item hidden" id="ape-breakdown">
                             <div class="breakdown-header">
                                 <div class="breakdown-icon ape-icon"></div>
                                 <div class="breakdown-info">
@@ -259,7 +259,7 @@
                             </div>
                         </div>
                         
-                        <div class="breakdown-item" id="bayc-breakdown" style="display: none;">
+                        <div class="breakdown-item hidden" id="bayc-breakdown">
                             <div class="breakdown-header">
                                 <div class="breakdown-icon bayc-icon"></div>
                                 <div class="breakdown-info">
@@ -283,7 +283,7 @@
                             </div>
                         </div>
                         
-                        <div class="breakdown-item" id="mayc-breakdown" style="display: none;">
+                        <div class="breakdown-item hidden" id="mayc-breakdown">
                             <div class="breakdown-header">
                                 <div class="breakdown-icon mayc-icon"></div>
                                 <div class="breakdown-info">
@@ -307,7 +307,7 @@
                             </div>
                         </div>
                         
-                        <div class="breakdown-item" id="bakc-breakdown" style="display: none;">
+                        <div class="breakdown-item hidden" id="bakc-breakdown">
                             <div class="breakdown-header">
                                 <div class="breakdown-icon bakc-icon"></div>
                                 <div class="breakdown-info">


### PR DESCRIPTION
## Summary
- ensure results container and breakdown items are initially hidden using the `hidden` class instead of inline styles
- this allows script.js to reveal them when calculations run

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844517fd5688333b5e9fa9e4c1f89ce