### PR TITLE
Update datasource list using API

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,9 @@
                     <h3 class="config-item-title">$APE Staking APY</h3>
                     <div class="config-source">
                         <a href="https://trackmyyield.xyz/" target="_blank" class="source-link">
-                            📈 Get from trackmyyield.xyz
+                            📈 trackmyyield.xyz
                         </a>
+                        <span class="source-info" id="config-source-ape-apy">Source: N/A</span>
                     </div>
                     <div class="config-input-group">
                         <label for="config-ape-apy">APY (%):</label>
@@ -79,8 +80,13 @@
                     <h3 class="config-item-title">NFT Staking Rewards</h3>
                     <div class="config-source">
                         <a href="https://apectrl.com/statistics/ape-staking" target="_blank" class="source-link">
-                            🦍 Get from apectrl.com
+                            🦍 apectrl.com
                         </a>
+                        <ul class="source-list">
+                            <li id="config-source-nft-bayc">BAYC: N/A</li>
+                            <li id="config-source-nft-mayc">MAYC: N/A</li>
+                            <li id="config-source-nft-bakc">BAKC: N/A</li>
+                        </ul>
                     </div>
                     <div class="config-inputs-row">
                         <div class="config-input-group">
@@ -103,11 +109,15 @@
                     <h3 class="config-item-title">Price Data</h3>
                     <div class="config-source">
                         <a href="https://coinmarketcap.com/currencies/apecoin-ape/" target="_blank" class="source-link">
-                            💰 APE Price from CoinMarketCap
+                            💰 CoinMarketCap
                         </a>
                         <a href="https://www.bloomberg.com/quote/USDCNY:CUR" target="_blank" class="source-link">
-                            💱 USD/CNY from Bloomberg
+                            💱 Bloomberg
                         </a>
+                        <ul class="source-list">
+                            <li id="config-source-ape-price">APE Price: N/A</li>
+                            <li id="config-source-usd-cny">USD/CNY Rate: N/A</li>
+                        </ul>
                     </div>
                     <div class="config-inputs-row">
                         <div class="config-input-group">
@@ -408,11 +418,13 @@
         
         <div class="data-source">
             <p><strong>Data Sources:</strong></p>
-            <ul class="source-list">
-                <li><a href="https://apectrl.com/statistics/ape-staking" target="_blank">apectrl.com - NFT Staking Rewards</a></li>
-                <li><a href="https://trackmyyield.xyz/" target="_blank">trackmyyield.xyz - APE Staking APY</a></li>
-                <li><a href="https://coinmarketcap.com/currencies/apecoin-ape/" target="_blank">CoinMarketCap - APE Price</a></li>
-                <li><a href="https://www.bloomberg.com/quote/USDCNY:CUR" target="_blank">Bloomberg - USD/CNY Rate</a></li>
+            <ul id="data-source-list" class="source-list">
+                <li id="source-ape-price">APE Price: N/A</li>
+                <li id="source-nft-staking-bayc">BAYC Staking: N/A</li>
+                <li id="source-nft-staking-mayc">MAYC Staking: N/A</li>
+                <li id="source-nft-staking-bakc">BAKC Staking: N/A</li>
+                <li id="source-ape-apy">APE APY: N/A</li>
+                <li id="source-usd-cny">USD/CNY Rate: N/A</li>
             </ul>
             <p><em>Use the Data Configuration panel above to manually update values from these sources.</em></p>
         </div>

--- a/script.js
+++ b/script.js
@@ -189,6 +189,24 @@ function updateDataStatus(source, timestamp) {
     if (domElements.lastUpdatedStatus) domElements.lastUpdatedStatus.textContent = timestamp;
 }
 
+function updateDataSourceList(sources = {}) {
+    if (domElements.sourceApePrice) domElements.sourceApePrice.textContent = `APE Price: ${sources.apePrice || 'N/A'}`;
+    if (domElements.sourceNftBayc) domElements.sourceNftBayc.textContent = `BAYC Staking: ${sources.nftStakingBAYC || 'N/A'}`;
+    if (domElements.sourceNftMayc) domElements.sourceNftMayc.textContent = `MAYC Staking: ${sources.nftStakingMAYC || 'N/A'}`;
+    if (domElements.sourceNftBakc) domElements.sourceNftBakc.textContent = `BAKC Staking: ${sources.nftStakingBAKC || 'N/A'}`;
+    if (domElements.sourceApeApy) domElements.sourceApeApy.textContent = `APE APY: ${sources.apeApy || 'N/A'}`;
+    if (domElements.sourceUsdCny) domElements.sourceUsdCny.textContent = `USD/CNY Rate: ${sources.usdCnyRate || 'N/A'}`;
+}
+
+function updateConfigSourceInfo(sources = {}) {
+    if (domElements.configSourceApeApy) domElements.configSourceApeApy.textContent = `Source: ${sources.apeApy || 'N/A'}`;
+    if (domElements.configSourceNftBayc) domElements.configSourceNftBayc.textContent = `BAYC: ${sources.nftStakingBAYC || 'N/A'}`;
+    if (domElements.configSourceNftMayc) domElements.configSourceNftMayc.textContent = `MAYC: ${sources.nftStakingMAYC || 'N/A'}`;
+    if (domElements.configSourceNftBakc) domElements.configSourceNftBakc.textContent = `BAKC: ${sources.nftStakingBAKC || 'N/A'}`;
+    if (domElements.configSourceApePrice) domElements.configSourceApePrice.textContent = `APE Price: ${sources.apePrice || 'N/A'}`;
+    if (domElements.configSourceUsdCny) domElements.configSourceUsdCny.textContent = `USD/CNY Rate: ${sources.usdCnyRate || 'N/A'}`;
+}
+
 // Notification system
 function showNotification(message, type = 'info') {
     // Create notification element
@@ -338,6 +356,8 @@ async function fetchLiveData() {
                     overallDataSource = 'Fetched Data (Source Info Missing)';
                 }
 
+                updateDataSourceList(data.dataSources);
+                updateConfigSourceInfo(data.dataSources);
                 updateDataStatus(overallDataSource, data.timestamp ? new Date(data.timestamp).toLocaleString() : new Date().toLocaleString());
                 showNotification('✅ Data updated!', 'success'); // General success message
                 
@@ -722,6 +742,22 @@ function cacheDomElements() {
     domElements.dataSourceStatus = document.getElementById('data-source-status');
     domElements.lastUpdatedStatus = document.getElementById('last-updated-status');
 
+    // Data Source list items
+    domElements.sourceApePrice = document.getElementById('source-ape-price');
+    domElements.sourceNftBayc = document.getElementById('source-nft-staking-bayc');
+    domElements.sourceNftMayc = document.getElementById('source-nft-staking-mayc');
+    domElements.sourceNftBakc = document.getElementById('source-nft-staking-bakc');
+    domElements.sourceApeApy = document.getElementById('source-ape-apy');
+    domElements.sourceUsdCny = document.getElementById('source-usd-cny');
+
+    // Config panel source info
+    domElements.configSourceApeApy = document.getElementById('config-source-ape-apy');
+    domElements.configSourceNftBayc = document.getElementById('config-source-nft-bayc');
+    domElements.configSourceNftMayc = document.getElementById('config-source-nft-mayc');
+    domElements.configSourceNftBakc = document.getElementById('config-source-nft-bakc');
+    domElements.configSourceApePrice = document.getElementById('config-source-ape-price');
+    domElements.configSourceUsdCny = document.getElementById('config-source-usd-cny');
+
     // Results Container & Breakdown
     domElements.resultsContainer = document.getElementById('results-container'); // Cached
     domElements.baycApeStaked = document.getElementById('bayc-ape-staked');
@@ -760,9 +796,13 @@ function loadInitialData() {
     if (savedData) {
         currentData = savedData;
         updateDataStatus('Saved Data', 'Loaded from browser storage');
+        updateDataSourceList();
+        updateConfigSourceInfo();
     } else {
         currentData = { ...DEFAULT_DATA }; // Use hardcoded defaults
         updateDataStatus('Default Values', 'Using system defaults');
+        updateDataSourceList();
+        updateConfigSourceInfo();
     }
 }
 


### PR DESCRIPTION
## Summary
- update data source list in the footer
- cache new elements and show actual sources from fetch-data API
- make data input panel show live sources

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68451ab1d8dc8333843788936796df0c